### PR TITLE
feat: added a tftest option via a flag and env var to set a go test t…

### DIFF
--- a/cmd/tftest/README.md
+++ b/cmd/tftest/README.md
@@ -88,7 +88,31 @@ For details on the required directory structure, see the [Directory Structure Do
 - `--module-root` - Path to the root of the Terraform module (runs all tests)
 - `--example-path` - Specific example to test (verifies both example and test directories exist)
 - `--common` - Run only common tests (verifies common directory exists)
+- `--timeout` - Test timeout duration (e.g., 20m, 1h). Can also be set via GO_TEST_TIMEOUT environment variable
+- `--parallel-fixtures` - Run test fixtures in parallel (default: false)
+- `--parallel-tests` - Run tests within each fixture in parallel (default: false)
 - `--help, -h` - Show help for the run command
+
+### ⏱️ Test Timeout Behavior
+
+**Important**: Go's test framework applies a default 10-minute timeout to the cumulative duration of ALL tests within a fixture, not per individual test. This means:
+
+- If you have multiple tests in a single fixture, they share the 10-minute timeout
+- The timeout applies to the entire test suite execution within that fixture
+- Individual tests within the fixture do not get their own separate 10-minute timeout
+
+To override this default timeout:
+
+```bash
+# Set timeout via command line flag
+tftest run --timeout=20m
+
+# Set timeout via environment variable
+export GO_TEST_TIMEOUT=20m
+tftest run
+
+# Environment variable takes precedence if both are set
+```
 
 ## 🔧 Options for 'format' command
 
@@ -107,3 +131,12 @@ For detailed information on how the commands work, see the [CLI Usage Documentat
 - Go 1.23 or later
 - A properly structured Terraform module with tests
 - AWS credentials (if testing AWS resources)
+
+## 🏗️ Test Architecture Notes
+
+When running tests with fixtures:
+
+- **Serial execution** (`--parallel-fixtures=false --parallel-tests=false`): Tests run sequentially, which is slower but produces minimal output volume to prevent overwhelming AI agents when debugging assistance is required
+- **Parallel execution**: Tests run concurrently, which is faster but generates extensive interleaved output that can exceed AI agent context limits
+
+For AI-assisted development workflows, implementing one test per testctx instance is recommended to maintain output volumes within AI agent processing capabilities.

--- a/cmd/tftest/cmd/run.go
+++ b/cmd/tftest/cmd/run.go
@@ -17,6 +17,7 @@ var (
 	commonOnly       bool
 	parallelFixtures bool
 	parallelTests    bool
+	testTimeout      string
 )
 
 // runCmd represents the run command
@@ -52,6 +53,7 @@ func init() {
 	runCmd.Flags().BoolVar(&commonOnly, "common", false, "Run only common tests")
 	runCmd.Flags().BoolVar(&parallelFixtures, "parallel-fixtures", false, "Run test fixtures in parallel (default: false)")
 	runCmd.Flags().BoolVar(&parallelTests, "parallel-tests", false, "Run tests within each fixture in parallel (default: false)")
+	runCmd.Flags().StringVar(&testTimeout, "timeout", "", "Test timeout duration (e.g., 20m, 1h)")
 }
 
 // runTests executes the tests based on the provided flags
@@ -120,8 +122,24 @@ func runTests() {
 	}
 	logger.Info("Starting tests...")
 
+	// Print environment variables for debugging
+	logger.Info("Environment variables:")
+	logger.Info("  GO_TEST_TIMEOUT=%s", os.Getenv("GO_TEST_TIMEOUT"))
+	logger.Info("  TERRATEST_IDEMPOTENCY=%s", os.Getenv("TERRATEST_IDEMPOTENCY"))
+	logger.Info("  AWS_PROFILE=%s", os.Getenv("AWS_PROFILE"))
+	logger.Info("  AWS_DEFAULT_REGION=%s", os.Getenv("AWS_DEFAULT_REGION"))
+
 	// Run the tests
 	args := []string{"test", testPath, "-v"}
+
+	// Add timeout if specified or from environment variable
+	timeoutValue := testTimeout
+	if timeoutValue == "" {
+		timeoutValue = os.Getenv("GO_TEST_TIMEOUT")
+	}
+	if timeoutValue != "" {
+		args = append(args, "-timeout", timeoutValue)
+	}
 
 	// Add -p 1 flag if parallelFixtures is false to disable parallel execution of test fixtures
 	if !parallelFixtures {

--- a/docs/TESTCTX_PACKAGE.md
+++ b/docs/TESTCTX_PACKAGE.md
@@ -10,6 +10,8 @@ The `testctx` package handles:
 - Parallel test execution control
 - Idempotency testing
 
+**Important**: Each use of `testctx` spins up a unique Terraform deployment that is tested and then destroyed. This means every call to `RunSingleExample`, `RunAllExamples`, etc. creates separate infrastructure instances for testing.
+
 ## Key Components
 
 ### TestContext
@@ -172,6 +174,76 @@ func TestDiscovery(t *testing.T) {
 }
 ```
 
+## Test Architecture & AI-Assisted Development
+
+### Deployment Lifecycle
+
+Each `testctx` usage follows this lifecycle:
+1. **Deploy**: Creates a unique Terraform deployment with generated resource names
+2. **Test**: Runs assertions against the deployed infrastructure
+3. **Destroy**: Automatically tears down all created resources
+
+This ensures test isolation but comes with infrastructure provisioning overhead.
+
+### AI-Assisted Development Considerations
+
+**Recommended Approach**: Use fewer tests per `testctx` (ideally 1 test per context)
+
+**Benefits**:
+- Smaller, focused test output that AI agents can easily parse and understand
+- Cleaner error messages when tests fail
+- Better context management for AI-assisted debugging
+- Easier to identify specific test failures
+
+**Trade-offs**:
+- Longer test cycles due to more separate deployments
+- Higher infrastructure provisioning overhead
+- Serial execution takes significantly longer
+
+**Alternative Approach**: Multiple tests per `testctx` for faster execution
+
+**Benefits**:
+- Faster test cycles (single deployment, multiple tests)
+- Lower infrastructure overhead
+- More efficient resource utilization
+
+**Trade-offs**:
+- Complex, interleaved test output that AI agents struggle to parse
+- Harder to isolate specific test failures
+- Large context sizes that may overwhelm AI agents
+
+### Choosing Your Strategy
+
+```go
+// AI-Friendly: One test per context (recommended for AI-assisted development)
+func TestVPCCreation(t *testing.T) {
+    ctx := testctx.RunSingleExample(t, "../../examples", "basic", testctx.TestConfig{
+        Name: "vpc-creation-test",
+    })
+    assertions.AssertOutputNotEmpty(t, ctx, "vpc_id")
+}
+
+func TestVPCTags(t *testing.T) {
+    ctx := testctx.RunSingleExample(t, "../../examples", "basic", testctx.TestConfig{
+        Name: "vpc-tags-test",
+    })
+    assertions.AssertOutputContains(t, ctx, "vpc_tags", "Environment")
+}
+
+// Efficiency-Focused: Multiple tests per context (faster but less AI-friendly)
+func TestVPCComprehensive(t *testing.T) {
+    ctx := testctx.RunSingleExample(t, "../../examples", "basic", testctx.TestConfig{
+        Name: "vpc-comprehensive-test",
+    })
+    
+    // Multiple tests in single deployment
+    assertions.AssertOutputNotEmpty(t, ctx, "vpc_id")
+    assertions.AssertOutputContains(t, ctx, "vpc_tags", "Environment")
+    assertions.AssertResourceCountExact(t, ctx, "aws_vpc", 1)
+    // ... many more tests
+}
+```
+
 ## Best Practices
 
 1. **Use RunSingleExample for Example-Specific Tests**: When writing tests for a specific example, use `RunSingleExample` to focus on that example.
@@ -183,3 +255,5 @@ func TestDiscovery(t *testing.T) {
 4. **Clean Up Resources**: The framework automatically cleans up Terraform resources, but if your tests create additional resources, clean them up.
 
 5. **Use Descriptive Test Names**: Set meaningful names in `TestConfig` to make test failures easier to understand.
+
+6. **Consider Your Development Workflow**: Choose between AI-friendly (fewer tests per context) or efficiency-focused (more tests per context) approaches based on your team's needs.


### PR DESCRIPTION
# Add Go Test Timeout Support to tftest CLI

## Description
Adds configurable timeout support to the `tftest run` command to override Go's default 10-minute test timeout. This addresses issues where Terraform infrastructure provisioning and testing takes longer than the default timeout, causing tests to fail prematurely.

The implementation adds:
- `--timeout` command line flag for specifying test duration (e.g., `20m`, `1h`)
- Support for `GO_TEST_TIMEOUT` environment variable
- Debug logging to show environment variables and executed commands
- Updated documentation explaining timeout behavior

## Type of change
- [x] New feature (non-breaking change which adds functionality)
- [x] Documentation update

## How Has This Been Tested?
- Tested with Terraform VPC module that requires >10 minutes for infrastructure provisioning
- Verified timeout flag works: `tftest run --timeout=20m`
- Verified environment variable works: `GO_TEST_TIMEOUT=20m tftest run`
- Confirmed debug output shows correct timeout values being applied
- Tested that timeout is properly passed to underlying `go test` command

Test command used:
```bash
# Set via environment variable
export GO_TEST_TIMEOUT=20m
tftest run --parallel-fixtures=false --parallel-tests=false

# Set via command line flag
tftest run --timeout=20m --parallel-fixtures=false --parallel-tests=false
